### PR TITLE
openblas rebuild for windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
-  

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
   

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,16 +1,37 @@
+@echo on
+SetLocal EnableDelayedExpansion
+
 mkdir build
 cd build
 
-cmake -G "NMake Makefiles JOM"              ^
+if "%USE_OPENMP%"=="1" (
+    REM https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860
+    set "CMAKE_EXTRA=-DOpenMP_ROOT=%LIBRARY_LIB%"
+    REM not picked up by `find_package(OpenMP)` for some reason
+    set "CMAKE_EXTRA=-DOpenMP_Fortran_FLAGS=-fopenmp -DOpenMP_Fortran_LIB_NAMES=libomp"
+)
+
+:: millions of lines of warnings with clang-19
+set "CFLAGS=%CFLAGS% -w"
+
+cmake -G "Ninja"                            ^
+    -DCMAKE_C_COMPILER=clang-cl             ^
+    -DCMAKE_Fortran_COMPILER=flang          ^
     -DCMAKE_BUILD_TYPE=Release              ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DDYNAMIC_ARCH=ON                       ^
     -DBUILD_WITHOUT_LAPACK=no               ^
+    -DNO_AVX512=1                           ^
     -DNOFORTRAN=0                           ^
     -DNUM_THREADS=128                       ^
-    ..
+    -DBUILD_SHARED_LIBS=on                  ^
+    -DUSE_OPENMP=%USE_OPENMP%               ^
+    !CMAKE_EXTRA!                           ^
+    %SRC_DIR%
+if %ERRORLEVEL% neq 0 exit 1
 
-jom install -j%CPU_COUNT%
+cmake --build . --target install
+if %ERRORLEVEL% neq 0 exit 1
 
-utest\openblas_utest.exe
-
+ctest -j2
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,14 @@
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20.1.8                 # [win]
+
+c_compiler:                # [win]
+  - clang                  # [win]
+cxx_compiler:              # [win]
+  - clang                  # [win]
+
+c_compiler_version:        # [win]
+  - 20.1.8                 # [win]
+cxx_compiler_version:      # [win]
+  - 20.1.8                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,10 @@ source:
 
 build:
   number: 1
-  # TODO
-  skip: true  # [not win]
 
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("fortran") }}
@@ -36,6 +35,7 @@ outputs:
       - Library/bin/openblas.dll           # [win]
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler("c") }}
         - {{ compiler("fortran") }}
     test:
@@ -72,8 +72,11 @@ outputs:
       - blas * openblas
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler("c") }}
         - {{ compiler("fortran") }}
+      host:
+        - {{ pin_subpackage("libopenblas", exact=True) }}
       run:
         - {{ pin_subpackage("libopenblas", exact=True) }}
         - nomkl
@@ -98,6 +101,8 @@ outputs:
   # openblas meta-package. It is better to require openblas-devel or libopenblas
   - name: openblas
     requirements:
+      host:
+        - {{ pin_subpackage("libopenblas", exact=True) }}
       run:
         - {{ pin_subpackage("libopenblas", exact=True) }}
         - {{ pin_subpackage("openblas-devel", exact=True) }}
@@ -106,6 +111,34 @@ outputs:
     test:
       commands:
         - exit 0
+
+    # mutex package to keep only one blas implementation in a given env
+    # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
+    # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
+    # so that it becomes unique per publish.
+  - name: blas
+    version: 1.0
+    build:
+      string: openblas
+      skip: true  # [not win]
+      # track_features doesn't really track anything anymore (blas metapackage
+      # dependencies do the same job better). This is still here, though, as it
+      # effectively "weighs down" nomkl packages, allowing mkl to take
+      # precedence when defaults is the top channel priority.
+      track_features:
+        - nomkl
+
+  - name: nomkl
+    version: 3.0
+    build:
+      string: "0"
+      number: 0
+      skip: true  # [not win]
+    requirements:
+      run:
+        - blas * openblas
+    about:
+      license: BSD-3-clause
 
 about:
   home: https://www.openblas.net/
@@ -118,32 +151,6 @@ about:
   description: OpenBLAS is based on GotoBLAS2 1.13 BSD version.
   doc_url: https://www.openblas.net/
   dev_url: https://github.com/xianyi/OpenBLAS
-
-  # mutex package to keep only one blas implementation in a given env
-  # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
-  # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
-  # so that it becomes unique per publish.
-#  - name: blas
-#    version: 1.0
-#    build:
-#      string: openblas
-#      # track_features doesn't really track anything anymore (blas metapackage
-#      # dependencies do the same job better). This is still here, though, as it
-#      # effectively "weighs down" nomkl packages, allowing mkl to take
-#      # precedence when defaults is the top channel priority.
-#      track_features:
-#        - nomkl
-
-  # - name: nomkl
-  #   version: 3.0
-  #   build:
-  #     string: "0"
-  #     number: 0
-  #   requirements:
-  #     run:
-  #       - blas * openblas
-  #   about:
-  #     license: BSD-3-clause
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ outputs:
       - lib/liblapack{{ SHLIB_EXT }}  # [unix]
       - lib/libopenblas*.so*          # [linux]
       - lib/libopenblas*.dylib        # [osx]
-      - Library/bin/openblas.dll           # [win]
+      - Library/bin/openblas.dll      # [win]
+      - Library/lib/openblas.lib      # [win]
     requirements:
       build:
         - {{ stdlib("c") }}
@@ -46,6 +47,7 @@ outputs:
         - nm -g ${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }} | grep dsecnd                        # [osx and build_platform=="osx-64"]
         - python -c "import ctypes; ctypes.cdll['${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }}']"  # [not win]
         - if not exist %PREFIX%\\Library\\bin\\openblas.dll exit 1                                            # [win]
+        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1                                            # [win]
 
     about:
       home: https://www.openblas.net/
@@ -86,7 +88,6 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/cblas.pc                      # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/lapack.pc                     # [not win]
         - test -f ${PREFIX}/site.cfg                                    # [not win]
-        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1  # [win]
     about:
       home: https://www.openblas.net/
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: {{ sha_hash }}
 
 build:
-  number: 0
-  skip: true  # [win]
+  number: 1
+  # TODO
+  skip: true  # [not win]
 
 requirements:
   build:


### PR DESCRIPTION
[PKG-6188](https://anaconda.atlassian.net/browse/PKG-6188)

## Changes
- Use the new flang compiler on windows
- Update build script
- Add back `blas` and `nomkl` outputs, but restrict to windows so we don't clobber other existing packages on other platforms.
- Fix win tests

[PKG-6188]: https://anaconda.atlassian.net/browse/PKG-6188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ