### PR TITLE
V0.3.30

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-# the conda-build parameters to use for disabling --skip-existing
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-
-channels:
-  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
-  

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+# It's critical to leave skip-existing enabled.
+# The blas/nomkl meta-packages should not be overwritten.
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,7 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
+
+channels:
+  - https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0
   

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,16 +1,37 @@
+@echo on
+SetLocal EnableDelayedExpansion
+
 mkdir build
 cd build
 
-cmake -G "NMake Makefiles JOM"              ^
+if "%USE_OPENMP%"=="1" (
+    REM https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860
+    set "CMAKE_EXTRA=-DOpenMP_ROOT=%LIBRARY_LIB%"
+    REM not picked up by `find_package(OpenMP)` for some reason
+    set "CMAKE_EXTRA=-DOpenMP_Fortran_FLAGS=-fopenmp -DOpenMP_Fortran_LIB_NAMES=libomp"
+)
+
+:: millions of lines of warnings with clang-19
+set "CFLAGS=%CFLAGS% -w"
+
+cmake -G "Ninja"                            ^
+    -DCMAKE_C_COMPILER=clang-cl             ^
+    -DCMAKE_Fortran_COMPILER=flang          ^
     -DCMAKE_BUILD_TYPE=Release              ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DDYNAMIC_ARCH=ON                       ^
     -DBUILD_WITHOUT_LAPACK=no               ^
+    -DNO_AVX512=1                           ^
     -DNOFORTRAN=0                           ^
     -DNUM_THREADS=128                       ^
-    ..
+    -DBUILD_SHARED_LIBS=on                  ^
+    -DUSE_OPENMP=%USE_OPENMP%               ^
+    !CMAKE_EXTRA!                           ^
+    %SRC_DIR%
+if %ERRORLEVEL% neq 0 exit 1
 
-jom install -j%CPU_COUNT%
+cmake --build . --target install
+if %ERRORLEVEL% neq 0 exit 1
 
-utest\openblas_utest.exe
-
+ctest -j2
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,14 @@
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20.1.8                 # [win]
+
+c_compiler:                # [win]
+  - clang                  # [win]
+cxx_compiler:              # [win]
+  - clang                  # [win]
+
+c_compiler_version:        # [win]
+  - 20.1.8                 # [win]
+cxx_compiler_version:      # [win]
+  - 20.1.8                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,10 @@ source:
 
 build:
   number: 1
-  # TODO
-  skip: true  # [not win]
 
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - {{ compiler("fortran") }}
@@ -36,6 +35,7 @@ outputs:
       - Library/bin/openblas.dll           # [win]
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler("c") }}
         - {{ compiler("fortran") }}
     test:
@@ -72,8 +72,11 @@ outputs:
       - blas * openblas
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler("c") }}
         - {{ compiler("fortran") }}
+      host:
+        - {{ pin_subpackage("libopenblas", exact=True) }}
       run:
         - {{ pin_subpackage("libopenblas", exact=True) }}
         - nomkl
@@ -98,6 +101,8 @@ outputs:
   # openblas meta-package. It is better to require openblas-devel or libopenblas
   - name: openblas
     requirements:
+      host:
+        - {{ pin_subpackage("libopenblas", exact=True) }}
       run:
         - {{ pin_subpackage("libopenblas", exact=True) }}
         - {{ pin_subpackage("openblas-devel", exact=True) }}
@@ -106,6 +111,34 @@ outputs:
     test:
       commands:
         - exit 0
+
+    # mutex package to keep only one blas implementation in a given env
+    # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
+    # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
+    # so that it becomes unique per publish.
+  - name: blas
+    version: 1.0
+    build:
+      string: openblas
+      skip: true  # [not win]
+      # track_features doesn't really track anything anymore (blas metapackage
+      # dependencies do the same job better). This is still here, though, as it
+      # effectively "weighs down" nomkl packages, allowing mkl to take
+      # precedence when defaults is the top channel priority.
+      track_features:
+        - nomkl
+
+  - name: nomkl
+    version: 3.0
+    build:
+      string: "0"
+      number: 0
+      skip: true  # [not win]
+    requirements:
+      run:
+        - blas * openblas
+    about:
+      license: BSD-3-clause
 
 about:
   home: https://www.openblas.net/
@@ -118,32 +151,6 @@ about:
   description: OpenBLAS is based on GotoBLAS2 1.13 BSD version.
   doc_url: https://www.openblas.net/
   dev_url: https://github.com/xianyi/OpenBLAS
-
-  # mutex package to keep only one blas implementation in a given env
-  # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
-  # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
-  # so that it becomes unique per publish.
-#  - name: blas
-#    version: 1.0
-#    build:
-#      string: openblas
-#      # track_features doesn't really track anything anymore (blas metapackage
-#      # dependencies do the same job better). This is still here, though, as it
-#      # effectively "weighs down" nomkl packages, allowing mkl to take
-#      # precedence when defaults is the top channel priority.
-#      track_features:
-#        - nomkl
-
-  # - name: nomkl
-  #   version: 3.0
-  #   build:
-  #     string: "0"
-  #     number: 0
-  #   requirements:
-  #     run:
-  #       - blas * openblas
-  #   about:
-  #     license: BSD-3-clause
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ outputs:
       - lib/liblapack{{ SHLIB_EXT }}  # [unix]
       - lib/libopenblas*.so*          # [linux]
       - lib/libopenblas*.dylib        # [osx]
-      - Library/bin/openblas.dll           # [win]
+      - Library/bin/openblas.dll      # [win]
+      - Library/lib/openblas.lib      # [win]
     requirements:
       build:
         - {{ stdlib("c") }}
@@ -46,6 +47,7 @@ outputs:
         - nm -g ${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }} | grep dsecnd                        # [osx and build_platform=="osx-64"]
         - python -c "import ctypes; ctypes.cdll['${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }}']"  # [not win]
         - if not exist %PREFIX%\\Library\\bin\\openblas.dll exit 1                                            # [win]
+        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1                                            # [win]
 
     about:
       home: https://www.openblas.net/
@@ -86,7 +88,6 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/cblas.pc                      # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/lapack.pc                     # [not win]
         - test -f ${PREFIX}/site.cfg                                    # [not win]
-        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1  # [win]
     about:
       home: https://www.openblas.net/
       license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "0.3.29" %}
-{% set sha_hash = "38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb" %}
+{% set version = "0.3.30" %}
+{% set sha_hash = "27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d" %}
 
 package:
   name: openblas_multipkg
@@ -8,9 +8,19 @@ package:
 source:
   url: https://github.com/OpenMathLib/OpenBLAS/archive/v{{ version }}.tar.gz
   sha256: {{ sha_hash }}
+  patches:
+    # It appears ld_classic flag requires xcode, which is not present in the CI system
+    - patches/0001-remove-ld_classic-flag.patch  # [osx]
+    # cimacopy and zimacopy tests fail on the CI system
+    # These tests pass locally. 
+    - patches/0002-disable-cimacopy-zimacopy-tests.patch  # [linux and aarch64]
+    - patches/0003-trmv.patch
 
 build:
-  number: 1
+  number: 0
+  script_env:
+    # Disable OpenMP for all platforms.
+    - USE_OPENMP=0
 
 requirements:
   build:
@@ -33,7 +43,6 @@ outputs:
       - lib/libopenblas*.so*          # [linux]
       - lib/libopenblas*.dylib        # [osx]
       - Library/bin/openblas.dll      # [win]
-      - Library/lib/openblas.lib      # [win]
     requirements:
       build:
         - {{ stdlib("c") }}
@@ -47,7 +56,7 @@ outputs:
         - nm -g ${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }} | grep dsecnd                        # [osx and build_platform=="osx-64"]
         - python -c "import ctypes; ctypes.cdll['${PREFIX}/lib/libopenblasp-r{{ version }}{{ SHLIB_EXT }}']"  # [not win]
         - if not exist %PREFIX%\\Library\\bin\\openblas.dll exit 1                                            # [win]
-        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1                                            # [win]
+        - if exist %PREFIX%\\Library\\lib\\openblas.lib exit 1                                                # [win]
 
     about:
       home: https://www.openblas.net/
@@ -69,6 +78,7 @@ outputs:
       - lib/pkgconfig/*blas.pc
       - lib/pkgconfig/lapack*.pc
       - site.cfg
+      - Library/lib/openblas.lib      # [win]
     run_exports:
       - {{ pin_subpackage("libopenblas") }}
       - blas * openblas
@@ -88,6 +98,7 @@ outputs:
         - test -f ${PREFIX}/lib/pkgconfig/cblas.pc                      # [not win]
         - test -f ${PREFIX}/lib/pkgconfig/lapack.pc                     # [not win]
         - test -f ${PREFIX}/site.cfg                                    # [not win]
+        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1      # [win]
     about:
       home: https://www.openblas.net/
       license: BSD-3-Clause
@@ -102,8 +113,6 @@ outputs:
   # openblas meta-package. It is better to require openblas-devel or libopenblas
   - name: openblas
     requirements:
-      host:
-        - {{ pin_subpackage("libopenblas", exact=True) }}
       run:
         - {{ pin_subpackage("libopenblas", exact=True) }}
         - {{ pin_subpackage("openblas-devel", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: {{ sha_hash }}
 
 build:
-  number: 0
-  skip: true  # [win]
+  number: 1
+  # TODO
+  skip: true  # [not win]
 
 requirements:
   build:

--- a/recipe/patches/0001-remove-ld_classic-flag.patch
+++ b/recipe/patches/0001-remove-ld_classic-flag.patch
@@ -1,0 +1,28 @@
+From 159af2287e199a02b8053dd9e0b48897fdd5de11 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Wed, 10 Sep 2025 14:42:11 -0600
+Subject: [PATCH 1/2] remove-ld_classic-flag
+
+---
+ Makefile.system | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/Makefile.system b/Makefile.system
+index 38646c3c6..d1bfa88aa 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -432,10 +432,7 @@ XCVER = $(shell pkgutil --pkg-info=com.apple.pkg.Xcode |awk '/version:/ {print $
+ ifeq (x$(XCVER)x,xx)
+ XCVER = $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables |awk '/version:/ {print $2}'|cut -d: -f2|cut -f1 -d.)
+ endif
+-ifeq (x$(XCVER), x 15)
+-CCOMMON_OPT += -Wl,-ld_classic
+-FCOMMON_OPT += -Wl,-ld_classic
+-endif
++
+ ifeq (x$(XCVER), x 16)
+ ifeq ($(F_COMPILER), GFORTRAN)
+ override CEXTRALIB := $(filter-out(-lto_library, $(CEXTRALIB))) 
+-- 
+2.45.2
+

--- a/recipe/patches/0002-disable-cimacopy-zimacopy-tests.patch
+++ b/recipe/patches/0002-disable-cimacopy-zimacopy-tests.patch
@@ -1,0 +1,41 @@
+From 1eab39ccb6a6c876957b3b28ffbf320df3609621 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Wed, 10 Sep 2025 14:58:48 -0600
+Subject: [PATCH 1/2] disable-cimacopy-zimacopy-tests
+
+---
+ utest/CMakeLists.txt | 4 ++--
+ utest/Makefile       | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/utest/CMakeLists.txt b/utest/CMakeLists.txt
+index 6a61899da..db019c7c5 100644
+--- a/utest/CMakeLists.txt
++++ b/utest/CMakeLists.txt
+@@ -54,8 +54,8 @@ ${DIR_EXT}/test_zomatcopy.c
+ ${DIR_EXT}/test_comatcopy.c
+ ${DIR_EXT}/test_simatcopy.c
+ ${DIR_EXT}/test_dimatcopy.c
+-${DIR_EXT}/test_cimatcopy.c
+-${DIR_EXT}/test_zimatcopy.c
++# ${DIR_EXT}/test_cimatcopy.c
++# ${DIR_EXT}/test_zimatcopy.c
+ ${DIR_EXT}/test_sgeadd.c
+ ${DIR_EXT}/test_dgeadd.c
+ ${DIR_EXT}/test_cgeadd.c
+diff --git a/utest/Makefile b/utest/Makefile
+index b82937093..b81682036 100644
+--- a/utest/Makefile
++++ b/utest/Makefile
+@@ -24,7 +24,7 @@ OBJS_EXT+=$(DIR_EXT)/test_samin.o $(DIR_EXT)/test_damin.o $(DIR_EXT)/test_scamin
+ OBJS_EXT+=$(DIR_EXT)/test_drotmg.o $(DIR_EXT)/test_srotmg.o $(DIR_EXT)/test_zrotg.o $(DIR_EXT)/test_crotg.o $(DIR_EXT)/test_crot.o $(DIR_EXT)/test_zrot.o
+ OBJS_EXT+=$(DIR_EXT)/test_zscal.o $(DIR_EXT)/test_cscal.o
+ OBJS_EXT+=$(DIR_EXT)/test_domatcopy.o $(DIR_EXT)/test_somatcopy.o $(DIR_EXT)/test_zomatcopy.o $(DIR_EXT)/test_comatcopy.o
+-OBJS_EXT+=$(DIR_EXT)/test_simatcopy.o $(DIR_EXT)/test_dimatcopy.o $(DIR_EXT)/test_cimatcopy.o $(DIR_EXT)/test_zimatcopy.o
++OBJS_EXT+=$(DIR_EXT)/test_simatcopy.o $(DIR_EXT)/test_dimatcopy.o
+ OBJS_EXT+=$(DIR_EXT)/test_sgeadd.o $(DIR_EXT)/test_dgeadd.o $(DIR_EXT)/test_cgeadd.o $(DIR_EXT)/test_zgeadd.o
+ OBJS_EXT+=$(DIR_EXT)/test_cgemv_t.o $(DIR_EXT)/test_zgemv_t.o $(DIR_EXT)/test_cgemv_n.o $(DIR_EXT)/test_zgemv_n.o
+ OBJS_EXT+=$(DIR_EXT)/test_sgemmt.o $(DIR_EXT)/test_dgemmt.o $(DIR_EXT)/test_cgemmt.o $(DIR_EXT)/test_zgemmt.o
+-- 
+2.45.2
+

--- a/recipe/patches/0003-trmv.patch
+++ b/recipe/patches/0003-trmv.patch
@@ -1,0 +1,25 @@
+From a9e8fa06bf11f174f339151a08978bcb3d49b59e Mon Sep 17 00:00:00 2001
+From: Martin Kroeker <martin@ruby.chemie.uni-freiburg.de>
+Date: Fri, 25 Jul 2025 15:15:46 +0200
+Subject: [PATCH] Introduce a (crude) threshold to multithreading
+
+Backport of https://patch-diff.githubusercontent.com/raw/OpenMathLib/OpenBLAS/pull/5403.patch
+
+---
+ interface/trmv.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/interface/tpmv.c b/interface/tpmv.c
+index 262af2285..1cb7366f0 100644
+--- a/interface/tpmv.c
++++ b/interface/tpmv.c
+@@ -223,6 +223,9 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
+ #ifdef SMP
+   nthreads = num_cpu_avail(2);
+ 
++  if (n < 50 ) nthreads = 1;
++  if (nthreads > 2 && n < 500) nthreads = 2;
++
+   if (nthreads == 1) {
+ #endif
+ 


### PR DESCRIPTION
[PKG-6188](https://anaconda.atlassian.net/browse/PKG-6188) &
[PKG-9045](https://anaconda.atlassian.net/browse/PKG-9045)

Continuation of #9 

## Changes
- Use the new flang compiler on windows
- Update build script
- Add back `blas` and `nomkl` outputs, but restrict to windows so we don't clobber other existing packages on other platforms.
- Fix win tests
- Two patches to work around CI issues.

## Notes
- downstream test results are attached. 

### Numpy

```
= 46788 passed, 1286 skipped, 1 deselected, 45 xfailed, 5 xpassed, 258 warnings in 166.32s (0:02:46) =
```

### Scipy

```
= 63536 passed, 4043 skipped, 191 xfailed, 12 xpassed, 2650 warnings in 131.53s (0:02:11) =
```

[PBP](https://package-build.anaconda.com/v1/graph/f44d3abe-a846-4f24-907e-aab3b836d290)

[test_libopenblas-0.3.30.zip](https://github.com/user-attachments/files/22278063/test_libopenblas-0.3.30.zip)


[PKG-6188]: https://anaconda.atlassian.net/browse/PKG-6188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-9045]: https://anaconda.atlassian.net/browse/PKG-9045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ