### PR TITLE
disable sme sgemm kernel

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,7 +8,9 @@ c_compiler:                # [win]
 cxx_compiler:              # [win]
   - clang                  # [win]
 
-c_compiler_version:        # [win]
+c_compiler_version:
   - 20.1.8                 # [win]
-cxx_compiler_version:      # [win]
+  - 17                     # [osx]
+cxx_compiler_version:
   - 20.1.8                 # [win]
+  - 17                     # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,29 +128,29 @@ outputs:
     # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
     # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
     # so that it becomes unique per publish.
-  - name: blas
-    version: 1.0
-    build:
-      string: openblas
-      skip: true  # [not win]
-      # track_features doesn't really track anything anymore (blas metapackage
-      # dependencies do the same job better). This is still here, though, as it
-      # effectively "weighs down" nomkl packages, allowing mkl to take
-      # precedence when defaults is the top channel priority.
-      track_features:
-        - nomkl
+  # - name: blas
+  #   version: 1.0
+  #   build:
+  #     string: openblas
+  #     skip: true
+  #     # track_features doesn't really track anything anymore (blas metapackage
+  #     # dependencies do the same job better). This is still here, though, as it
+  #     # effectively "weighs down" nomkl packages, allowing mkl to take
+  #     # precedence when defaults is the top channel priority.
+  #     track_features:
+  #       - nomkl
 
-  - name: nomkl
-    version: 3.0
-    build:
-      string: "0"
-      number: 0
-      skip: true  # [not win]
-    requirements:
-      run:
-        - blas * openblas
-    about:
-      license: BSD-3-clause
+  # - name: nomkl
+  #   version: 3.0
+  #   build:
+  #     string: "0"
+  #     number: 0
+  #     skip: true
+  #   requirements:
+  #     run:
+  #       - blas * openblas
+  #   about:
+  #     license: BSD-3-clause
 
 about:
   home: https://www.openblas.net/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,11 @@ source:
     # These tests pass locally. 
     - patches/0002-disable-cimacopy-zimacopy-tests.patch  # [linux and aarch64]
     - patches/0003-trmv.patch
+    # Remove once https://github.com/OpenMathLib/OpenBLAS/issues/5414 is resolved. 
+    - patches/0004-disable-sme-sgemm-kernel.patch
 
 build:
-  number: 0
+  number: 1
   script_env:
     # Disable OpenMP for all platforms.
     - USE_OPENMP=0

--- a/recipe/patches/0004-disable-sme-sgemm-kernel.patch
+++ b/recipe/patches/0004-disable-sme-sgemm-kernel.patch
@@ -1,0 +1,25 @@
+From 316e7316b2d4329eaf91c68389f2e34a452e2f76 Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Mon, 10 Nov 2025 14:25:01 -0700
+Subject: [PATCH 1/1] disable-sme-sgemm-kernel
+
+---
+ driver/others/dynamic_arm64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/driver/others/dynamic_arm64.c b/driver/others/dynamic_arm64.c
+index 70b51f6fc..d9b297117 100644
+--- a/driver/others/dynamic_arm64.c
++++ b/driver/others/dynamic_arm64.c
+@@ -472,7 +472,7 @@ static gotoblas_t *get_coretype(void) {
+   }
+ 
+ #if !defined(NO_SME)
+-  if (support_sme1()) {
++  if (false) {
+     return &gotoblas_ARMV9SME;
+   }
+ #endif
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
[PKG-10730](https://anaconda.atlassian.net/browse/PKG-10730)

- Disable SME kernel until upstream is fixed.
- Use clang 17 on OSX ( the same that the original build was built with). 20 was leading to mysterious `clang: error: no input files` errors. 
- Disable the meta-packages. The versions don't change and they already exist. Don't risk uploading duplicates. 

[PKG-10730]: https://anaconda.atlassian.net/browse/PKG-10730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ