### PR TITLE
Generate pkg-config files on windows too.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -26,12 +26,29 @@ cmake -G "Ninja"                            ^
     -DNUM_THREADS=128                       ^
     -DBUILD_SHARED_LIBS=on                  ^
     -DUSE_OPENMP=%USE_OPENMP%               ^
+    -DBUILD_PKGCONFIG=ON                    ^
     !CMAKE_EXTRA!                           ^
     %SRC_DIR%
 if %ERRORLEVEL% neq 0 exit 1
 
 cmake --build . --target install
 if %ERRORLEVEL% neq 0 exit 1
+
+REM Create pkg-config files for standard BLAS/CBLAS/LAPACK names
+REM This mirrors what the Unix build does in build.sh lines 171-175
+mkdir "%LIBRARY_PREFIX%\lib\pkgconfig" 2>nul
+if exist "%LIBRARY_PREFIX%\lib\pkgconfig\openblas.pc" (
+    copy "%LIBRARY_PREFIX%\lib\pkgconfig\openblas.pc" "%LIBRARY_PREFIX%\lib\pkgconfig\blas.pc"
+    copy "%LIBRARY_PREFIX%\lib\pkgconfig\openblas.pc" "%LIBRARY_PREFIX%\lib\pkgconfig\cblas.pc"  
+    copy "%LIBRARY_PREFIX%\lib\pkgconfig\openblas.pc" "%LIBRARY_PREFIX%\lib\pkgconfig\lapack.pc"
+)
+
+REM Create site.cfg file for numpy compatibility  
+REM This mirrors what the Unix build does in build.sh lines 186-189
+copy "%RECIPE_DIR%\site.cfg" "%LIBRARY_PREFIX%\site.cfg"
+echo library_dirs = %LIBRARY_PREFIX%\lib >> "%LIBRARY_PREFIX%\site.cfg"
+echo include_dirs = %LIBRARY_PREFIX%\include >> "%LIBRARY_PREFIX%\site.cfg"  
+echo runtime_include_dirs = %LIBRARY_PREFIX%\lib >> "%LIBRARY_PREFIX%\site.cfg"
 
 ctest -j2
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/0004-disable-sme-on-apple-silicon.patch
 
 build:
-  number: 2
+  number: 3
   script_env:
     # Disable OpenMP for all platforms.
     - USE_OPENMP=0
@@ -76,11 +76,15 @@ outputs:
       - include/*blas.h
       - include/lapack*.h
       - include/openblas_config.h
-      - lib/cmake/openblas
-      - lib/pkgconfig/*blas.pc
-      - lib/pkgconfig/lapack*.pc
-      - site.cfg
-      - Library/lib/openblas.lib      # [win]
+      - lib/cmake/openblas                    # [not win]
+      - lib/pkgconfig/*blas.pc                # [not win]
+      - lib/pkgconfig/lapack*.pc              # [not win]
+      - Library/lib/cmake/openblas            # [win]
+      - Library/lib/pkgconfig/*blas.pc        # [win]
+      - Library/lib/pkgconfig/lapack*.pc      # [win]
+      - site.cfg                              # [not win]
+      - Library/site.cfg                      # [win]
+      - Library/lib/openblas.lib              # [win]
     run_exports:
       - {{ pin_subpackage("libopenblas") }}
       - blas * openblas
@@ -96,11 +100,15 @@ outputs:
         - nomkl
     test:
       commands:
-        - test -f ${PREFIX}/lib/pkgconfig/blas.pc                       # [not win]
-        - test -f ${PREFIX}/lib/pkgconfig/cblas.pc                      # [not win]
-        - test -f ${PREFIX}/lib/pkgconfig/lapack.pc                     # [not win]
-        - test -f ${PREFIX}/site.cfg                                    # [not win]
-        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1      # [win]
+        - test -f ${PREFIX}/lib/pkgconfig/blas.pc                          # [not win]
+        - test -f ${PREFIX}/lib/pkgconfig/cblas.pc                         # [not win]
+        - test -f ${PREFIX}/lib/pkgconfig/lapack.pc                        # [not win]
+        - test -f ${PREFIX}/site.cfg                                       # [not win]
+        - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\blas.pc exit 1    # [win]
+        - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\cblas.pc exit 1   # [win]
+        - if not exist %PREFIX%\\Library\\lib\\pkgconfig\\lapack.pc exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\site.cfg exit 1                   # [win]
+        - if not exist %PREFIX%\\Library\\lib\\openblas.lib exit 1          # [win]
     about:
       home: https://www.openblas.net/
       license: BSD-3-Clause


### PR DESCRIPTION
openblas rebuild: Adds pkg-config support to windows

### Changes
- Generate pc files and site.cfg, matching existing unix logic
- Add tests to ensure they are there  

### Notes
- Verified it fixes building numpy here: https://github.com/AnacondaRecipes/numpy-feedstock/pull/128