### PR TITLE
Add generated anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,8 @@
+anaconda_config_version: 1
+upstream_sources:
+  - github:
+      identifier: xianyi/OpenBLAS
+    packages:
+      - libopenblas
+      - openblas
+      - openblas-devel

--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,7 +1,7 @@
 anaconda_config_version: 1
 upstream_sources:
   - github:
-      identifier: xianyi/OpenBLAS
+      identifier: OpenMathLib/OpenBLAS
     packages:
       - libopenblas
       - openblas


### PR DESCRIPTION
This PR adds generated `anaconda.yaml` (Feedstock Configuration Format).

See https://github.com/AnacondaRecipes/openblas-feedstock/blob/master/recipe/meta.yaml#L9

and it was https://github.com/anaconda/package-reporting/blob/main/inputs/pkg_info.csv#L1615