### PR TITLE
Win arm64

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,10 +16,12 @@ set "CFLAGS=%CFLAGS% -w"
 
 cmake -G "Ninja"                            ^
     -DCMAKE_C_COMPILER=clang-cl             ^
+    -DCMAKE_CXX_COMPILER=clang-cl           ^
     -DCMAKE_Fortran_COMPILER=flang          ^
     -DCMAKE_BUILD_TYPE=Release              ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-    -DDYNAMIC_ARCH=ON                       ^
+    -DDYNAMIC_ARCH=OFF                      ^
+    -DTARGET=ARMV8                          ^
     -DBUILD_WITHOUT_LAPACK=no               ^
     -DNO_AVX512=1                           ^
     -DNOFORTRAN=0                           ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,6 +15,7 @@ if "%USE_OPENMP%"=="1" (
 set "CFLAGS=%CFLAGS% -w"
 
 if /i "%SUBDIR%"=="win-arm64" (
+    REM getarch incorrectly chooses CORE=A64FX for arm64, so we need to force it to ARMV8
     set "CMAKE_ARCH_ARGS=-DDYNAMIC_ARCH=OFF -DTARGET=ARMV8"
 ) else (
     set "CMAKE_ARCH_ARGS=-DDYNAMIC_ARCH=ON"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,14 +14,19 @@ if "%USE_OPENMP%"=="1" (
 :: millions of lines of warnings with clang-19
 set "CFLAGS=%CFLAGS% -w"
 
+if /i "%SUBDIR%"=="win-arm64" (
+    set "CMAKE_ARCH_ARGS=-DDYNAMIC_ARCH=OFF -DTARGET=ARMV8"
+) else (
+    set "CMAKE_ARCH_ARGS=-DDYNAMIC_ARCH=ON"
+)
+
 cmake -G "Ninja"                            ^
     -DCMAKE_C_COMPILER=clang-cl             ^
     -DCMAKE_CXX_COMPILER=clang-cl           ^
     -DCMAKE_Fortran_COMPILER=flang          ^
     -DCMAKE_BUILD_TYPE=Release              ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-    -DDYNAMIC_ARCH=OFF                      ^
-    -DTARGET=ARMV8                          ^
+    !CMAKE_ARCH_ARGS!                       ^
     -DBUILD_WITHOUT_LAPACK=no               ^
     -DNO_AVX512=1                           ^
     -DNOFORTRAN=0                           ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,7 +14,7 @@ if "%USE_OPENMP%"=="1" (
 :: millions of lines of warnings with clang-19
 set "CFLAGS=%CFLAGS% -w"
 
-if /i "%SUBDIR%"=="win-arm64" (
+if /i "%target_platform%"=="win-arm64" (
     REM getarch incorrectly chooses CORE=A64FX for arm64, so we need to force it to ARMV8
     set "CMAKE_ARCH_ARGS=-DDYNAMIC_ARCH=OFF -DTARGET=ARMV8"
 ) else (

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,11 +8,6 @@ if [[ ${target_platform} != linux-aarch64 ]] && [[ ${target_platform} != linux-6
     ulimit -s 50000
 fi
 
-# Fix segfault issue arising from a bug in Linux 2.6.32; we can probably skip
-# this patch once we drop support for CentOS/RHEL 6.x. For details, see:
-# https://github.com/xianyi/OpenBLAS/wiki/faq#Linux_SEGFAULT
-patch < segfaults.patch
-
 # Build configuration options
 declare -a build_opts
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,3 +14,6 @@ c_compiler_version:
 cxx_compiler_version:
   - 20.1.8                 # [win]
   - 17                     # [osx]
+
+perl:
+  - 5.42

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,6 +14,3 @@ c_compiler_version:
 cxx_compiler_version:
   - 20.1.8                 # [win]
   - 17                     # [osx]
-
-perl:
-  - 5.42

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - cmake                      # [win]
     - curl                       # [win]
     - jom                        # [win]
+    - ninja                      # [win]
     - make                       # [unix]
     - objconv                    # [osx]
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -136,29 +136,29 @@ outputs:
     # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
     # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
     # so that it becomes unique per publish.
-  # - name: blas
-  #   version: 1.0
-  #   build:
-  #     string: openblas
-  #     skip: true
-  #     # track_features doesn't really track anything anymore (blas metapackage
-  #     # dependencies do the same job better). This is still here, though, as it
-  #     # effectively "weighs down" nomkl packages, allowing mkl to take
-  #     # precedence when defaults is the top channel priority.
-  #     track_features:
-  #       - nomkl
+  - name: blas
+    version: 1.0
+    build:
+      string: openblas
+      skip: false
+      # track_features doesn't really track anything anymore (blas metapackage
+      # dependencies do the same job better). This is still here, though, as it
+      # effectively "weighs down" nomkl packages, allowing mkl to take
+      # precedence when defaults is the top channel priority.
+      track_features:
+        - nomkl
 
-  # - name: nomkl
-  #   version: 3.0
-  #   build:
-  #     string: "0"
-  #     number: 0
-  #     skip: true
-  #   requirements:
-  #     run:
-  #       - blas * openblas
-  #   about:
-  #     license: BSD-3-clause
+  - name: nomkl
+    version: 3.0
+    build:
+      string: "0"
+      number: 0
+      skip: false
+    requirements:
+      run:
+        - blas * openblas
+    about:
+      license: BSD-3-clause
 
 about:
   home: https://www.openblas.net/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - cmake                      # [win]
     - curl                       # [win]
     - jom                        # [win]
-    - ninja                      # [win]
+    - ninja-base                 # [win]
     - make                       # [unix]
     - objconv                    # [osx]
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -142,29 +142,29 @@ outputs:
     # Since this package has a non-unique name, blas-1.0-openblas.conda, it is omitted from future updates as they cause issues
     # with overwrites on the PBP. If an update to this package is needed in the future, the name should have a hash added
     # so that it becomes unique per publish.
-  - name: blas
-    version: 1.0
-    build:
-      string: openblas
-      skip: false
-      # track_features doesn't really track anything anymore (blas metapackage
-      # dependencies do the same job better). This is still here, though, as it
-      # effectively "weighs down" nomkl packages, allowing mkl to take
-      # precedence when defaults is the top channel priority.
-      track_features:
-        - nomkl
+  # - name: blas
+  #   version: 1.0
+  #   build:
+  #     string: openblas
+  #     skip: true
+  #     # track_features doesn't really track anything anymore (blas metapackage
+  #     # dependencies do the same job better). This is still here, though, as it
+  #     # effectively "weighs down" nomkl packages, allowing mkl to take
+  #     # precedence when defaults is the top channel priority.
+  #     track_features:
+  #       - nomkl
 
-  - name: nomkl
-    version: 3.0
-    build:
-      string: "0"
-      number: 0
-      skip: false
-    requirements:
-      run:
-        - blas * openblas
-    about:
-      license: BSD-3-clause
+  # - name: nomkl
+  #   version: 3.0
+  #   build:
+  #     string: "0"
+  #     number: 0
+  #     skip: true
+  #   requirements:
+  #     run:
+  #       - blas * openblas
+  #   about:
+  #     license: BSD-3-clause
 
 about:
   home: https://www.openblas.net


### PR DESCRIPTION
openblas rebuild with win-arm64 compatibility

https://anaconda.atlassian.net/browse/PKG-15386

- Adds ninja-base for windows which is using Ninja generator
- Bump build number
- Disable `DYNAMIC_ARCH` for win-arm64 as it's incorrectly identifying incorrect archs. 